### PR TITLE
Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ package-lock.json
 package.json
 .vscode/
 node_modules/*
+
+# Ignore .env file where contributors will store their GitHub API Tokens. We
+# don't want them to accidentally push them to the repo.
+.env


### PR DESCRIPTION
Include the `.env` file in the `.gitignore` to prevent contributors to accidentally push their API Tokens to the repository.


---

This PR was created during SciPy2024 sprints.