### PR TITLE
Update nox instructions and install pyosmetrics in html session

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ or [`pipx` for global install](https://pipx.pypa.io/stable/):
 
 To build the html version of the dashboard use
 
-`nox -s build`
+`nox -s html`
 
 ### Build a live local server dashboard
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,6 +10,7 @@ build_execute = ["build", "--html", "--execute"]
 @nox.session
 def html(session):
     session.install("-r", "requirements.txt")
+    session.install("-e", "./pyosmetrics_pkg")
     cmd = ["myst"]
     cmd.extend(build_execute + session.posargs)
     session.run(*cmd)


### PR DESCRIPTION
Update nox instructions in README.md: the `build` session doesn't exist, use the `html` one instead. Install `pyosmetrics` on the `html` nox session.
