### PR TITLE
Update editorial-dashboard.qmd to fix editor count mismatch

### DIFF
--- a/peer-review/editorial-dashboard.qmd
+++ b/peer-review/editorial-dashboard.qmd
@@ -139,7 +139,7 @@ available_editors = available_editors[["editor", "review count", "Domain_areas",
 dict(
   icon = "box2-heart",
   color = "primary",
-  value = len(all_editor_activity)
+  value = len(all_editors_df)
 )
 ```
 


### PR DESCRIPTION
File : metrics -> peer-review -> editorial-dashboard.qmd
Change value = len(editor_data) to value = len(all_editor_activity) at line.no : 142
This aligns all three metrics to the same base and resolves the mismatch. As stated by: Vamsi-aki